### PR TITLE
Fix multiple definition errors

### DIFF
--- a/honeyd.c
+++ b/honeyd.c
@@ -128,6 +128,8 @@ struct conlru udplru;
 
 struct spoof no_spoof;	/* spoof settings for default packet processing */
 
+struct event_base *libevent_base;
+
 struct config config = {
 	NULL,
 	PATH_HONEYDDATA "/nmap-os-db",

--- a/honeyd.h
+++ b/honeyd.h
@@ -56,7 +56,7 @@
 
 #include "compat/sys/tree.h"
 
-struct event_base *libevent_base;
+extern struct event_base *libevent_base;
 
 struct config {
 	char *config;	 /* Name of configuration file */

--- a/honeydstats.c
+++ b/honeydstats.c
@@ -77,6 +77,8 @@
 #include "honeydstats.h"
 #include "analyze.h"
 
+struct event_base *libevent_base;
+
 /* Stubs to make it compile */
 
 int pcap_datalink(void *some) {	return (-1); }

--- a/honeydstats.c
+++ b/honeydstats.c
@@ -78,6 +78,7 @@
 #include "analyze.h"
 
 struct event_base *libevent_base;
+struct event_base *stats_libevent_base;
 
 /* Stubs to make it compile */
 

--- a/honeydstats.h
+++ b/honeydstats.h
@@ -48,7 +48,7 @@ struct user {
 
 SPLAY_HEAD(usertree, user);
 
-struct event_base *stats_libevent_base;
+extern struct event_base *stats_libevent_base;
 
 int signature_process(struct evbuffer *evbuf);
 void checkpoint_replay(int fd);

--- a/hsniff.c
+++ b/hsniff.c
@@ -80,6 +80,8 @@
 #include "stats.h"
 #include "debug.h"
 
+struct event_base *libevent_base;
+
 int			honeyd_debug;
 
 static int		hsniff_show_version;

--- a/personality.c
+++ b/personality.c
@@ -72,6 +72,9 @@ int npersons;
 struct personate person_drop = {};
 static struct timeval tv_periodic;
 
+struct perstree personalities;
+struct xp_fprint_tree xp_fprints;
+
 SPLAY_GENERATE(perstree, personality, node, perscompare);
 
 /* ET - For the Xprobe fingerprint tree */

--- a/personality.h
+++ b/personality.h
@@ -292,7 +292,8 @@ void xprobe_personality_init(void);
 void print_perstree(void);
 
 /* Splay stuff here so other modules can use it */
-SPLAY_HEAD(perstree, personality) personalities;
+SPLAY_HEAD(perstree, personality);
+extern struct perstree personalities;
 static int
 perscompare(struct personality *a, struct personality *b)
 {
@@ -300,7 +301,8 @@ perscompare(struct personality *a, struct personality *b)
 }
 SPLAY_PROTOTYPE(perstree, personality, node, perscompare);
 
-SPLAY_HEAD(xp_fprint_tree, xp_fingerprint) xp_fprints;
+SPLAY_HEAD(xp_fprint_tree, xp_fingerprint);
+extern struct xp_fprint_tree xp_fprints;
 static int 
 xp_fprint_compare(struct xp_fingerprint *a, struct xp_fingerprint *b)
 {

--- a/rrdtool.c
+++ b/rrdtool.c
@@ -62,6 +62,7 @@
 
 extern rand_t *honeyd_rand;
 
+struct event_base *rrdtool_libevent_base;
 
 static void rrdtool_restart(int, short, void *);
 static void rrdtool_write_command(struct rrdtool_drv *, char *);

--- a/rrdtool.h
+++ b/rrdtool.h
@@ -44,7 +44,7 @@ struct rrdtool_command {
 
 #define MAX_RRD_DATASRCS	100
 
-struct event_base *rrdtool_libevent_base;
+extern struct event_base *rrdtool_libevent_base;
 
 struct rrdtool_drv {
 	int fd;

--- a/stats.c
+++ b/stats.c
@@ -75,6 +75,9 @@ static void stats_make_fd(struct addr *, u_short);
 static void stats_activate(struct stats *stats);
 static void stats_deactivate(struct stats *stats);
 
+enum measurement_tags_type measurement_tags;
+enum signature_tags_type signature_tags;
+
 /* Many static variables.  We don't like them */
 
 /* We might have other consumers of our created records */

--- a/stats.h
+++ b/stats.h
@@ -91,9 +91,10 @@ struct stats {
 		reserved:4;
 };
 
-enum {
+enum measurement_tags_type {
 	M_COUNTER, M_TV_START, M_TV_END, M_RECORD, M_MAX
-} measurement_tags;
+};
+extern enum measurement_tags_type measurement_tags;
 
 struct measurement {
 	uint32_t counter;
@@ -105,9 +106,10 @@ struct measurement {
 #define SHA1_DIGESTSIZE	20
 #endif
 
-enum {
+enum signature_tags_type {
 	SIG_NAME, SIG_DIGEST, SIG_DATA, SIG_COMPRESSED_DATA, SIG_MAX
-} signature_tags;
+}; 
+extern enum signature_tags_type signature_tags;
 
 struct signature {
 	char *name;

--- a/tagging.c
+++ b/tagging.c
@@ -58,6 +58,9 @@
 
 #include "tagging.h"
 
+enum RECORD_TAGS record_tags;
+enum ADDRESS_TAGS address_tags;
+
 void
 tag_marshal_record(struct evbuffer *evbuf, uint8_t tag, struct record *record)
 {

--- a/tagging.h
+++ b/tagging.h
@@ -42,11 +42,12 @@ struct hash {
 	u_char digest[SHINGLE_SIZE];
 };
 
-enum {
+enum RECORD_TAGS {
 	REC_TV_START, REC_TV_END, REC_SRC, REC_DST, REC_SRC_PORT, REC_DST_PORT,
 	REC_PROTO, REC_STATE, REC_OS_FP, REC_HASH, REC_BYTES, REC_FLAGS,
 	REC_MAX_TAGS
-} record_tags;
+};
+extern enum RECORD_TAGS record_tags;
 
 #define RECORD_STATE_NEW	0x01
 
@@ -67,9 +68,10 @@ struct record {
 	TAILQ_HEAD(hashq, hash) hashes;	/* optional */
 };
 
-enum {
+enum ADDRESS_TAGS {
 	ADDR_TYPE, ADDR_BITS, ADDR_ADDR, ADDR_MAX_TAGS
-} address_tags;
+}; 
+extern enum ADDRESS_TAGS address_tags;
 
 void record_marshal(struct evbuffer *, struct record *);
 


### PR DESCRIPTION
Some global variables are defined in header files, which get included in multiple translation units. This leads to linker errors using some linkers, because the C standard does not allow multiple definitions of the same variable.

This PR moves those variables to implementation files and changes the definitions to declarations in the header files.